### PR TITLE
Unicode function problem in python3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,10 @@
 pyAvroPhonetic
 ==============
 
+**NOTICE:**: This repository is not maintained any longer. Please take a look at this `auvipy's fork`_, for further developments.
+
+----
+
 A Python implementation of the popular Bengali phonetic-typing software
 `Avro Phonetic`_.
 
@@ -184,3 +188,4 @@ The full license text can be found in ``LICENSE``.
    :target: https://travis-ci.org/kaustavdm/pyAvroPhonetic
 .. _Md Enzam Hossain: https://github.com/ienzam
 .. _Sarim Khan: https://github.com/sarim
+.. _auvipy's fork: https://github.com/auvipy/pyAvroPhonetic


### PR DESCRIPTION
There is a problem when I was using this.
`  print(avro.parse("kal"))
  File "C:\Program Files\Python36\lib\site-packages\pyavrophonetic\avro.py", line 52, in parse
    fixed_text = validate.fix_string_case(utf(text))
  File "C:\Program Files\Python36\lib\site-packages\pyavrophonetic\utils\__init__.py", line 29, in utf
    output = unicode(text, encoding='utf-8')
NameError: name 'unicode' is not defined`

I fixed this problem by modifying in a line of __init__.py line 29:
`def utf(text):`
`     try:`
`         output = str(text, encoding='utf-8')`
`     except UnicodeDecodeError:`
`          output = text`
`     except TypeError:`
`           output = text`
`     return output`
